### PR TITLE
Updated PostgisBuilder \Closure instead of Closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,16 @@
 {
     "name": "lamb/laravel-postgis-database",
-    "description": "An extended Postgres driver for Laravel 4 that provides support for PostGIS features.",
-    "keywords": ["postgis", "database", "laravel"],
+    "description": "An extended Postgres driver for Laravel 4 that provides support for PostGIS and BSON features.",
+    "keywords": ["postgis", "bson", "database", "laravel"],
     "license": "MIT", 
     "authors": [
         {
             "name": "Greg Lamb",
             "email": "email@greglamb.me"
+        },
+        {
+            "name": "Alex Goretoy",
+            "email": "alex@goretoy.com"
         }
     ],
     "require": {

--- a/src/Lamb/LaravelPostgisDatabase/PostgisBlueprint.php
+++ b/src/Lamb/LaravelPostgisDatabase/PostgisBlueprint.php
@@ -14,4 +14,8 @@ class PostgisBlueprint extends Blueprint {
 		return $this->addColumn('polygon', $column);
 	}
 
+	public function bson($column)
+	{
+		return $this->addColumn('bson', $column);
+	}
 }

--- a/src/Lamb/LaravelPostgisDatabase/PostgisBuilder.php
+++ b/src/Lamb/LaravelPostgisDatabase/PostgisBuilder.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Schema\Builder;
 
 class PostgisBuilder extends Builder {
 
-	protected function createBlueprint($table, Closure $callback = null)
+	protected function createBlueprint($table, \Closure $callback = null)
 	{
 		return new PostgisBlueprint($table, $callback);
 	}

--- a/src/Lamb/LaravelPostgisDatabase/PostgisSchemaGrammar.php
+++ b/src/Lamb/LaravelPostgisDatabase/PostgisSchemaGrammar.php
@@ -14,5 +14,9 @@ class PostgisSchemaGrammar extends PostgresGrammar {
 	{
 		return 'geography(Polygon,4326)';
 	}
-
+	
+	protected function typeBson(Fluent $column)
+	{
+		return 'bson';
+	}
 }

--- a/src/Lamb/LaravelPostgisDatabase/PostgisSchemaGrammar.php
+++ b/src/Lamb/LaravelPostgisDatabase/PostgisSchemaGrammar.php
@@ -7,12 +7,12 @@ class PostgisSchemaGrammar extends PostgresGrammar {
 
 	protected function typePoint(Fluent $column)
 	{
-		return 'geography(Point,4326)';
+		return 'point';
 	}
 	
 	protected function typePolygon(Fluent $column)
 	{
-		return 'geography(Polygon,4326)';
+		return 'polygon';
 	}
 	
 	protected function typeBson(Fluent $column)


### PR DESCRIPTION
fixes composer error:

[ErrorException]                                                                                                                                                                                                                            
  Argument 2 passed to Lamb\LaravelPostgisDatabase\PostgisBuilder::createBlueprint() must be an instance of Lamb\LaravelPostgisDatabase\Closure, instance of Closure given, called in .../vendor/laravel/framework  
  /src/Illuminate/Database/Schema/Builder.php on line 94 and defined